### PR TITLE
chore(*): bump node-installer image to v0.15.1

### DIFF
--- a/marketplace/charts/spinkube-azure-marketplace/values.yaml
+++ b/marketplace/charts/spinkube-azure-marketplace/values.yaml
@@ -42,7 +42,7 @@ global:
         image: kwasm-operator
         registry: ghcr.io/kwasm
       kwasmOperatorInstallerImage:
-        tag: v0.14.1
+        tag: v0.15.1
         image: node-installer
         registry: ghcr.io/spinkube/containerd-shim-spin
 

--- a/values.yaml
+++ b/values.yaml
@@ -7,4 +7,4 @@ cert-manager:
 kwasm-operator:
   enabled: true
   kwasmOperator:
-    installerImage: ghcr.io/spinkube/containerd-shim-spin/node-installer:v0.14.1
+    installerImage: ghcr.io/spinkube/containerd-shim-spin/node-installer:v0.15.1


### PR DESCRIPTION
Bumps the node-installer image to https://github.com/spinkube/containerd-shim-spin/releases/tag/v0.15.1