### PR TITLE
chore(.helmignore): ignore marketplace, .github for root chart

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -21,3 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
+marketplace/
+.github/


### PR DESCRIPTION
Adds a few more dirs to .helmignore

Motivated by hitting the following error recently:

```
$ helm upgrade --install --wait spinkube .
Release "spinkube" does not exist. Installing it now.
Error: create: failed to create: Request entity too large: limit is 3145728
```
and reading up on the [corresponding helm issue](https://github.com/helm/helm/issues/7264)