### PR TITLE
chore(marketplace): bump version to 1.1.0

### DIFF
--- a/marketplace/manifest.yaml
+++ b/marketplace/manifest.yaml
@@ -1,7 +1,7 @@
 applicationName: spinkube
 publisher: "Fermyon"
 description: "SpinKube on Azure Marketplace"
-version: 1.0.5 #Must be in the format of #.#.#
+version: 1.1.0 #Must be in the format of #.#.#
 helmChart: "./charts/spinkube-azure-marketplace"
 clusterArmTemplate: "./mainTemplate.json"
 uiDefinition: "./createUIDefinition.json"


### PR DESCRIPTION
Bump marketplace bundle version to 1.1.0 in preparation for the next [release](https://github.com/spinkube/azure/tree/main/marketplace#release-process).  This release mainly consists of bumping Spin Operator to [0.3.0](https://github.com/spinkube/azure/pull/14) (no breaking changes).