### PR TITLE
fix(marketplace): limit extension name to 14 characters

### DIFF
--- a/marketplace/createUIDefinition.json
+++ b/marketplace/createUIDefinition.json
@@ -224,11 +224,11 @@
 						"type": "Microsoft.Common.TextBox",
 						"label": "Cluster extension resource name",
 						"defaultValue": "",
-						"toolTip": "Only lowercase alphanumeric characters are allowed, and the value must be 6-30 characters long.",
+						"toolTip": "Only lowercase alphanumeric characters are allowed, and the value must be 6-14 characters long.",
 						"constraints": {
 							"required": true,
-							"regex": "^[a-z0-9]{6,30}$",
-							"validationMessage": "Only lowercase alphanumeric characters are allowed, and the value must be 6-30 characters long."
+							"regex": "^[a-z0-9]{6,14}$",
+							"validationMessage": "Only lowercase alphanumeric characters are allowed, and the value must be 6-14 characters long."
 						},
 						"visible": true
 					}


### PR DESCRIPTION
Limit the extension name to 14 characters.

A 63-character limit applies to [certain K8s resource names](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names) and some of the names generated from their respective helm templates can be quite long, eg `<extension name>-spin-operator-controller-manager-metrics-service`.