### PR TITLE
feat(marketplace): add default kubernetes version

### DIFF
--- a/marketplace/createUIDefinition.json
+++ b/marketplace/createUIDefinition.json
@@ -131,6 +131,7 @@
 								"name": "kubernetesVersion",
 								"type": "Microsoft.Common.DropDown",
 								"label": "Kubernetes version",
+								"defaultValue": "1.29.7",
 								"toolTip": "The version of Kubernetes that should be used for this cluster. You will be able to upgrade this version after creating the cluster.",
 								"constraints": {
 									"allowedValues": "[map(steps('clusterDetails').newClusterSection.aksVersionLookupControl.properties.orchestrators, (item) => parse(concat('{\"label\":\"', item.orchestratorVersion, '\",\"value\":\"', item.orchestratorVersion, '\"}')))]",


### PR DESCRIPTION
- Adds a default K8s version in the corresponding dropdown.

As of writing, AKS pre-selects 1.29.7 as the default version for new clusters, hence using the same here.