### PR TITLE
fix(marketplace): update apiVersion in mainTemplate.json per cpa verify failure

### DIFF
--- a/marketplace/mainTemplate.json
+++ b/marketplace/mainTemplate.json
@@ -140,7 +140,7 @@
       {
           "type": "Microsoft.ContainerService/managedClusters",
           "condition": "[parameters('createNewCluster')]",
-          "apiVersion": "2022-11-01",
+          "apiVersion": "2023-05-01",
           "name": "[parameters('clusterResourceName')]",
           "location": "[parameters('location')]",
           "dependsOn": [],


### PR DESCRIPTION
Updates the Microsoft.ContainerService/managedClusters apiVersion to a more recent version to fix the [cpa verify error seen here](https://github.com/spinkube/azure/actions/runs/11690509045/job/32555599816?pr=29).  It now matches the version we're already using for the Microsoft.KubernetesConfiguration/extensions resource.