### PR TITLE
chore(marketplace): bump to 1.2.0

### DIFF
--- a/marketplace/manifest.yaml
+++ b/marketplace/manifest.yaml
@@ -1,7 +1,7 @@
 applicationName: spinkube
 publisher: "Fermyon"
 description: "SpinKube on Azure Marketplace"
-version: 1.1.1 #Must be in the format of #.#.#
+version: 1.2.0 #Must be in the format of #.#.#
 helmChart: "./charts/spinkube-azure-marketplace"
 clusterArmTemplate: "./mainTemplate.json"
 uiDefinition: "./createUIDefinition.json"


### PR DESCRIPTION
Bumping the marketplace chart version to 1.2.0 in prep for the next release, following [the release docs](https://github.com/spinkube/azure/tree/main/marketplace#release-process).

Placing in draft because I think we'll want updated Spin Operator and shim versions as well, prior to the next release; ref https://github.com/spinkube/azure/issues/30

Note: bumping Spin Operator _will_ be a breaking change (per their CRD domain name update) but since we haven't published the Marketplace extension to the public yet, I'm inclined to stay at 1.x until we do so.

[Diff from v1.1.1](https://github.com/spinkube/azure/compare/v1.1.1...main)

## Main changes

- Annotate nodes on upgrade to support upgrading shim version: https://github.com/spinkube/azure/pull/35
- Add pre-delete and post-delete webhooks to the marketplace chart to block helm uninstall if Spin App CRDs exist (pre-delete) or thoroughly clean up installation when deletion can proceed (post-delete): https://github.com/spinkube/azure/pull/29
- Bump Spin Operator to v0.4.0: https://github.com/spinkube/azure/pull/33
- Bump containerd shim spin to v0.16.0: https://github.com/spinkube/azure/pull/34

