### PR TITLE
chore(values.yaml): bump node-installer to v0.16.0

### DIFF
--- a/marketplace/charts/spinkube-azure-marketplace/values.yaml
+++ b/marketplace/charts/spinkube-azure-marketplace/values.yaml
@@ -42,7 +42,7 @@ global:
         image: kwasm-operator
         registry: ghcr.io/kwasm
       kwasmOperatorInstallerImage:
-        tag: v0.15.1
+        tag: v0.16.0
         image: node-installer
         registry: ghcr.io/spinkube/containerd-shim-spin
       kwasmOperatorTestConnectionWget:

--- a/values.yaml
+++ b/values.yaml
@@ -7,4 +7,4 @@ cert-manager:
 kwasm-operator:
   enabled: true
   kwasmOperator:
-    installerImage: ghcr.io/spinkube/containerd-shim-spin/node-installer:v0.15.1
+    installerImage: ghcr.io/spinkube/containerd-shim-spin/node-installer:v0.16.0


### PR DESCRIPTION
Bumps the shim to [v0.16.0](https://github.com/spinkube/containerd-shim-spin/releases/tag/v0.16.0)

(Realized we hadn't bumped to this version, even though the next 0.17.0 release is anticipated soon.)