### PR TITLE
feat(marketplace): also annotate nodes on upgrade to support shim upgrade

### DIFF
--- a/.github/workflows/marketplace-smoke-test.yaml
+++ b/.github/workflows/marketplace-smoke-test.yaml
@@ -24,6 +24,8 @@ jobs:
       - name: create kind cluster
         uses: helm/kind-action@v1
 
+      ## Install SpinKube and verify Spin App runs
+
       - name: helm install spinkube
         run: |
           helm install spinkube \
@@ -56,6 +58,25 @@ jobs:
       - name: Verify curl
         run: curl localhost:8083/hello
 
+      ## Upgrade release and verify shim is re-installed
+
+      - name: delete any lingering kwasm jobs
+        run: kubectl -n spinkube delete job -l kwasm.sh/job=true
+
+      - name: helm upgrade spinkube and watch for annotate and install job completions
+        run: |
+          helm upgrade spinkube \
+            --wait \
+            --namespace spinkube \
+            --debug \
+            marketplace/charts/spinkube-azure-marketplace &
+          timeout 30s bash -c 'until [[ "$(kubectl -n spinkube get job -l job-name=spinkube-kwasm-annotate-nodes -o json | jq '.items[].spec.completions')" == "1" ]]; do sleep 2; done'
+          timeout 30s bash -c 'until [[ "$(kubectl -n spinkube get job -l kwasm.sh/job=true -o json | jq '.items[].spec.completions')" == "1" ]]; do sleep 2; done'
+
+      ## Delete release
+
+      # First, verify deletion is blocked when Spin App resources exist
+
       - name: helm delete spinkube
         run: |
           if helm delete spinkube --timeout 1m --namespace spinkube; then
@@ -79,6 +100,8 @@ jobs:
 
       - name: Delete Spin App
         run: kubectl delete spinapp simple-spinapp
+
+      # Now verify deletion proceeds and no resources remain
 
       - name: helm delete spinkube
         run: helm delete spinkube --timeout 1m --namespace spinkube

--- a/marketplace/charts/spinkube-azure-marketplace/templates/kwasm-annotate-nodes-job.yaml
+++ b/marketplace/charts/spinkube-azure-marketplace/templates/kwasm-annotate-nodes-job.yaml
@@ -18,9 +18,9 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |-
-            echo "Annotating node with kwasm.sh/kwasm-node=false to reset installation of the shim for upgrade scenarios"
+            echo "Annotating nodes with kwasm.sh/kwasm-node=false to reset installation of the shim for upgrade scenarios"
             kubectl annotate node --all kwasm.sh/kwasm-node=false --overwrite
-            echo "Annotating node with kwasm.sh/kwasm-node=true to (re-)trigger installation of the shim"
+            echo "Annotating nodes with kwasm.sh/kwasm-node=true to (re-)trigger installation of the shim"
             kubectl annotate node --all kwasm.sh/kwasm-node=true --overwrite
       restartPolicy: OnFailure
 ---

--- a/marketplace/charts/spinkube-azure-marketplace/templates/kwasm-annotate-nodes-job.yaml
+++ b/marketplace/charts/spinkube-azure-marketplace/templates/kwasm-annotate-nodes-job.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   name: "{{ .Release.Name }}-kwasm-annotate-nodes"
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-4"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
@@ -15,8 +15,13 @@ spec:
       containers:
       - name: kubectl
         image: {{ printf "%s/%s:%s" .Values.global.azure.images.kubectl.registry .Values.global.azure.images.kubectl.image .Values.global.azure.images.kubectl.tag }}
-        command: ["kubectl"]
-        args: ["annotate", "node", "--all", "kwasm.sh/kwasm-node=true"]
+        command: ["/bin/sh", "-c"]
+        args:
+          - |-
+            echo "Annotating node with kwasm.sh/kwasm-node=false to reset installation of the shim for upgrade scenarios"
+            kubectl annotate node --all kwasm.sh/kwasm-node=false --overwrite
+            echo "Annotating node with kwasm.sh/kwasm-node=true to (re-)trigger installation of the shim"
+            kubectl annotate node --all kwasm.sh/kwasm-node=true --overwrite
       restartPolicy: OnFailure
 ---
 apiVersion: v1


### PR DESCRIPTION
- Updates the kwasm-annotate-nodes Job to also run on helm upgrades, to support upgrading shim version

We could also try to make this logic smarter, for instance if there was a way to know if we are executing via the 'helm-upgrade' hook, we could inspect which nodes are already labeled with `kwasm.sh/kwasm-node=true` and do the re-labeling just on this subset, rather than re-labeling all nodes.  Thoughts?