### PR TITLE
chore(marketplace): bump default k8s version to 1.29.10

### DIFF
--- a/marketplace/mainTemplate.json
+++ b/marketplace/mainTemplate.json
@@ -66,7 +66,7 @@
       },
       "kubernetesVersion": {
           "type": "String",
-          "defaultValue": "1.28.9",
+          "defaultValue": "1.29.10",
           "metadata": {
               "description": "The version of Kubernetes."
           }

--- a/marketplace/parameterFile.json
+++ b/marketplace/parameterFile.json
@@ -30,7 +30,7 @@
       "value": 0
     },
     "kubernetesVersion": {
-      "value": "1.28.9"
+      "value": "1.29.10"
     },
     "networkPlugin": {
       "value": "kubenet"


### PR DESCRIPTION
- Bump the default k8s version to match the current AKS default