### PR TITLE
chore(node-installer): bump to v0.17.0

### DIFF
--- a/marketplace/charts/spinkube-azure-marketplace/values.yaml
+++ b/marketplace/charts/spinkube-azure-marketplace/values.yaml
@@ -42,7 +42,7 @@ global:
         image: kwasm-operator
         registry: ghcr.io/kwasm
       kwasmOperatorInstallerImage:
-        tag: v0.16.0
+        tag: v0.17.0
         image: node-installer
         registry: ghcr.io/spinkube/containerd-shim-spin
       kwasmOperatorTestConnectionWget:

--- a/values.yaml
+++ b/values.yaml
@@ -7,4 +7,4 @@ cert-manager:
 kwasm-operator:
   enabled: true
   kwasmOperator:
-    installerImage: ghcr.io/spinkube/containerd-shim-spin/node-installer:v0.16.0
+    installerImage: ghcr.io/spinkube/containerd-shim-spin/node-installer:v0.17.0


### PR DESCRIPTION
Bump the shim node-installer image to [v0.17.0](https://github.com/spinkube/containerd-shim-spin/releases/tag/v0.17.0)