### PR TITLE
chore(marketplace): bump to 1.3.0

### DIFF
--- a/marketplace/manifest.yaml
+++ b/marketplace/manifest.yaml
@@ -1,7 +1,7 @@
 applicationName: spinkube
 publisher: "Fermyon"
 description: "SpinKube on Azure Marketplace"
-version: 1.2.1 #Must be in the format of #.#.#
+version: 1.3.0 #Must be in the format of #.#.#
 helmChart: "./charts/spinkube-azure-marketplace"
 clusterArmTemplate: "./mainTemplate.json"
 uiDefinition: "./createUIDefinition.json"


### PR DESCRIPTION
Bumps the marketplace version to 1.3.0.

These are the current planned changes since [1.2.1](https://github.com/spinkube/azure/releases/tag/v1.2.1):
- [x] Bump default k8s version to 1.29.10: https://github.com/spinkube/azure/pull/40
- [x] Bump containerd-shim-spin/node-installer to v0.17.0: https://github.com/spinkube/azure/pull/41