### PR TITLE
chore(marketplace/mainTemplate.json): bump managedClusters api version to 2025-10-01

### DIFF
--- a/marketplace/mainTemplate.json
+++ b/marketplace/mainTemplate.json
@@ -140,7 +140,7 @@
       {
           "type": "Microsoft.ContainerService/managedClusters",
           "condition": "[parameters('createNewCluster')]",
-          "apiVersion": "2023-05-01",
+          "apiVersion": "2025-10-01",
           "name": "[parameters('clusterResourceName')]",
           "location": "[parameters('location')]",
           "dependsOn": [],


### PR DESCRIPTION
I noticed the marketplace verify CI job failing recently with:
```
Write-Error: /home/runner/work/azure/azure/arm-ttk/arm-ttk/Test-AzTemplate.ps1:253
Line |
 253 |                      . $myModule $TheTest @testInput 2>&1 3>&1
     |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Api versions must be the latest or under 2 years old (730 days) - API
     | version 2023-05-01 of Microsoft.ContainerService/managedClusters is 1018
     | days old
```

Hence, bumping to the latest stable version per [upstream documentation](https://learn.microsoft.com/en-us/azure/templates/microsoft.containerservice/2025-10-01/managedclusters?pivots=deployment-language-arm-template).